### PR TITLE
Update meson-g12b-s922x-oes-plus.dts

### DIFF
--- a/arch/arm64/boot/dts/amlogic/meson-g12b-s922x-oes-plus.dts
+++ b/arch/arm64/boot/dts/amlogic/meson-g12b-s922x-oes-plus.dts
@@ -289,7 +289,7 @@
 	status = "okay";
 	phy-mode = "rgmii";
 	phy-handle = <&rtl8211f>;
-	amlogic,tx-delay-ns = <2>;
+	amlogic,tx-delay-ns = <4>;
 };
 
 &ext_mdio {


### PR DESCRIPTION
fixed eth0 unstable issue, has been tesed on OES-PLUS V2.1 and V2.2